### PR TITLE
dsl interface to access fips county codes

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -20,7 +20,7 @@ Jeweler::Tasks.new do |gem|
   gem.summary = %Q{data structures for querying FIPS codes}
   #gem.description = %Q{TODO: longer description of your gem}
   gem.email = "hembree@nationbuilder.com"
-  gem.authors = ["hembree"]
+  gem.authors = ["hembree", "mgbatchelor"]
   # dependencies defined in Gemfile
 end
 Jeweler::RubygemsDotOrgTasks.new

--- a/lib/fips_code.rb
+++ b/lib/fips_code.rb
@@ -1,0 +1,14 @@
+module FipsCountyCodes
+  class FipsCode
+    attr_reader :state, :county
+
+    def initialize(state, county)
+      @state = state
+      @county = county
+    end
+
+    def to_a
+      [state, county].freeze
+    end
+  end
+end

--- a/lib/fips_county_codes.rb
+++ b/lib/fips_county_codes.rb
@@ -18,7 +18,7 @@ module FipsCountyCodes
   end
 
   def self.as_list
-    @@as_list ||= FIPS.values.map{|state| state.as_list}.flatten
+    @@as_list ||= FIPS.values.map{|state| state.as_list}.reduce(:concat)
   end
 
   def self.load_fips_data

--- a/lib/fips_county_codes.rb
+++ b/lib/fips_county_codes.rb
@@ -1,44 +1,11 @@
 require 'csv'
+require_relative 'fips_code'
+require_relative 'fips_state'
 
 module FipsCountyCodes
 
   FIPS = {}
   STATE_COUNTY = {}
-
-  class FipsCode
-    attr_reader :state, :county
-
-    def initialize(state, county)
-      @state = state
-      @county = county
-    end
-
-    def to_a
-      [state, county].freeze
-    end
-  end
-
-  class FipsState
-    attr_reader :fips
-
-    def initialize(fips)
-      @fips = fips
-      @counties = {}
-    end
-
-    def []=(county_name, fips)
-      @counties[county_name] = fips
-    end
-
-    def county(county_name)
-      @counties[county_name]
-    end
-
-    def counties
-      @counties.dup
-    end
-
-  end
 
   def self.fips(county_code)
     return STATE_COUNTY[county_code] if STATE_COUNTY.has_key? county_code
@@ -47,7 +14,11 @@ module FipsCountyCodes
 
   def self.state(state)
     return FIPS[state] if FIPS.has_key? state
-    FipsState.new("")
+    FipsState.new("", "")
+  end
+
+  def self.as_list
+    @@as_list ||= FIPS.values.map{|state| state.as_list}.flatten
   end
 
   def self.load_fips_data
@@ -60,7 +31,7 @@ module FipsCountyCodes
       fips_code = "#{state_code}#{county_code}"
 
       unless FIPS.has_key? state
-        FIPS[state] = FipsState.new(long_state_code)
+        FIPS[state] = FipsState.new(long_state_code, state)
         STATE_COUNTY[long_state_code] = FipsCode.new(state, "All Counties")
       end
 
@@ -71,6 +42,7 @@ module FipsCountyCodes
     end
     FIPS.freeze
     STATE_COUNTY.freeze
+    as_list
   end
 
   self.load_fips_data

--- a/lib/fips_state.rb
+++ b/lib/fips_state.rb
@@ -1,0 +1,23 @@
+module FipsCountyCodes
+  class FipsState
+    attr_reader :fips, :name
+
+    def initialize(fips, name)
+      @fips = fips
+      @name = name
+      @counties = {}
+    end
+
+    def []=(county_name, fips)
+      @counties[county_name] = fips
+    end
+
+    def county(county_name)
+      @counties[county_name]
+    end
+
+    def as_list
+      @as_list ||= @counties.map{|c, f| ["#{name} - #{c} - #{f}", f] }
+    end
+  end
+end

--- a/test/fips_lookups_spec.rb
+++ b/test/fips_lookups_spec.rb
@@ -43,7 +43,7 @@ describe "Mapping (State, County) between (NISTCodes Code)" do
     end
 
     it "creates a list of all counties" do
-      FipsCountyCodes.as_list.count.should eq 12484
+      FipsCountyCodes.as_list.count.should eq 6242
     end
 
   end

--- a/test/fips_lookups_spec.rb
+++ b/test/fips_lookups_spec.rb
@@ -1,14 +1,24 @@
-require_relative 'helper'
+require_relative "helper"
 
-describe 'Mapping (State, County) between (NISTCodes Code)' do
+describe "Mapping (State, County) between (NISTCodes Code)" do
 
-  it 'looks up a fips for a state and county' do
-    FipsCountyCodes::FIPS['CA']['Los Angeles'].should == "06037"
-    FipsCountyCodes::FIPS['CA']['Los Angeles County'].should == "06037"
+  it "looks up a fips for a state and county" do
+    FipsCountyCodes.state("CA").county("Los Angeles").should == "06037"
+    FipsCountyCodes.state("CA").county("Los Angeles County").should == "06037"
+    FipsCountyCodes.state("CA").fips.should == "06000"
+    FipsCountyCodes.state("CA").counties.count.should == 116 # should include 06000 all counties?
   end
 
-  it 'looks up a state and county' do
-    FipsCountyCodes::STATE_COUNTY["06037"].should == ['CA', 'Los Angeles County']
+  it "looks up a state and county" do
+    FipsCountyCodes.fips("06037").state.should == "CA"
+    FipsCountyCodes.fips("06037").county.should == "Los Angeles County"
+    FipsCountyCodes.fips("06037").to_a.should == ["CA", "Los Angeles County"]
+  end
+
+  it "looks for a fips that does not exist" do
+    FipsCountyCodes.fips("99999").state.should == ""
+    FipsCountyCodes.fips("99999").county.should == ""
+    FipsCountyCodes.fips("99999").to_a.should == ["", ""]
   end
 
   it "looks up codes from a frozen hash" do
@@ -17,12 +27,12 @@ describe 'Mapping (State, County) between (NISTCodes Code)' do
   end
 
   it "returns frozen arrays" do
-    FipsCountyCodes::STATE_COUNTY["06037"].should be_frozen
-    FipsCountyCodes::STATE_COUNTY["06000"].should be_frozen
+    FipsCountyCodes.fips("06037").to_a.frozen?.should be_true
+    FipsCountyCodes.fips("06000").to_a.frozen?.should be_true
   end
 
   it "has an entry for each state scoped to all counties" do
-    FipsCountyCodes::STATE_COUNTY["06000"].should == ['CA', 'All Counties']
+    FipsCountyCodes.fips("06000").to_a.should == ["CA", "All Counties"]
   end
 
 end

--- a/test/fips_lookups_spec.rb
+++ b/test/fips_lookups_spec.rb
@@ -6,7 +6,7 @@ describe "Mapping (State, County) between (NISTCodes Code)" do
     FipsCountyCodes.state("CA").county("Los Angeles").should == "06037"
     FipsCountyCodes.state("CA").county("Los Angeles County").should == "06037"
     FipsCountyCodes.state("CA").fips.should == "06000"
-    FipsCountyCodes.state("CA").counties.count.should == 116 # should include 06000 all counties?
+    FipsCountyCodes.state("CA").name.should == "CA"
   end
 
   it "looks up a state and county" do
@@ -33,6 +33,19 @@ describe "Mapping (State, County) between (NISTCodes Code)" do
 
   it "has an entry for each state scoped to all counties" do
     FipsCountyCodes.fips("06000").to_a.should == ["CA", "All Counties"]
+  end
+
+  context "#as_list" do
+
+    it "creates a list of counties" do
+      FipsCountyCodes.state("CA").as_list.count.should eq 116
+      FipsCountyCodes.state("CA").as_list.first.should eq ["CA - Alameda County - 06001", "06001"]
+    end
+
+    it "creates a list of all counties" do
+      FipsCountyCodes.as_list.count.should eq 12484
+    end
+
   end
 
 end


### PR DESCRIPTION
This change introduces two classes `FipsState` and `FipsCode` to allow a DSL language to retrieve and find a state or county name from a code, or vice-versa.

@DavidHembree  @ccollins @brettbevers @bugsbycarlin 

This breaks the old interface. So it would have to be a minor revision bump.